### PR TITLE
support "options" attribute for ssh_authorized_key type

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This is the top class which can be just included somewhere: with according param
           'second-test-key' => {
             type => 'ssh-rsa',
             key  => 'AAAAB3NzaC1yc2EAAAADAQABAAABAQCqlo0PPGZ2XW1qBFuFgYmsGlT24I+v51tb7cRSAJeBouDPvfqBMBOX84ye4DsW3uRmFNXt/wdAr/QnEAlua5bSagVRC2t9X4lkcrFJSSfEA2J29Lh16pPzOK/HReo8R89wbEKfqrqZG/FNrjMB6YaAxBRJE0O9T6BDsMBCg6b8wb6DRPIKzuEkKkI9ywExVrVFOEANTsdS0oQq8exIlWHmnKwOf1R2Jl1FRgIHnJAfG29EoeY7Q+DlPZOBXqB+xamYj56h6FMb0ZLBOAirXm76bHbqJhzY5RbcW8HrxzvLBY1xfOlP4NMKWIxBNG1j2Je0WPU9gVDnq7/LoS0OuCtR',
+            options => [ 'command="deployScript.sh"', 'no-agent-forwarding', 'no-port-forwarding' ],
           },
         },
       },
@@ -81,6 +82,10 @@ sshkeys::keys:
   second-test-key:
     type: 'ssh-rsa'
     key: 'AAAAB3NzaC1yc2EAAAADAQABAAABAQCqlo0PPGZ2XW1qBFuFgYmsGlT24I+v51tb7cRSAJeBouDPvfqBMBOX84ye4DsW3uRmFNXt/wdAr/QnEAlua5bSagVRC2t9X4lkcrFJSSfEA2J29Lh16pPzOK/HReo8R89wbEKfqrqZG/FNrjMB6YaAxBRJE0O9T6BDsMBCg6b8wb6DRPIKzuEkKkI9ywExVrVFOEANTsdS0oQq8exIlWHmnKwOf1R2Jl1FRgIHnJAfG29EoeY7Q+DlPZOBXqB+xamYj56h6FMb0ZLBOAirXm76bHbqJhzY5RbcW8HrxzvLBY1xfOlP4NMKWIxBNG1j2Je0WPU9gVDnq7/LoS0OuCtR'
+    options:
+      - 'command="deployScript.sh"'
+      - 'no-agent-forwarding'
+      - 'no-port-forwarding'
 # hash with users in the hiera structure. The hash is merged with hiera_hash lookup
 sshkeys::users:
   sometestuser:
@@ -116,6 +121,7 @@ sshkeys::user supports all important parameters for useradd [User](puppet_user) 
       'second-test-key' => {
         type => 'ssh-rsa',
         key  => 'AAAAB3NzaC1yc2EAAAADAQABAAABAQCqlo0PPGZ2XW1qBFuFgYmsGlT24I+v51tb7cRSAJeBouDPvfqBMBOX84ye4DsW3uRmFNXt/wdAr/QnEAlua5bSagVRC2t9X4lkcrFJSSfEA2J29Lh16pPzOK/HReo8R89wbEKfqrqZG/FNrjMB6YaAxBRJE0O9T6BDsMBCg6b8wb6DRPIKzuEkKkI9ywExVrVFOEANTsdS0oQq8exIlWHmnKwOf1R2Jl1FRgIHnJAfG29EoeY7Q+DlPZOBXqB+xamYj56h6FMb0ZLBOAirXm76bHbqJhzY5RbcW8HrxzvLBY1xfOlP4NMKWIxBNG1j2Je0WPU9gVDnq7/LoS0OuCtR',
+        options => [ 'command="deployScript.sh"', 'no-agent-forwarding', 'no-port-forwarding' ],
       },
     },
   }
@@ -132,6 +138,10 @@ sshkeys::keys:
   second-test-key:
     type: 'ssh-rsa'
     key: 'AAAAB3NzaC1yc2EAAAADAQABAAABAQCqlo0PPGZ2XW1qBFuFgYmsGlT24I+v51tb7cRSAJeBouDPvfqBMBOX84ye4DsW3uRmFNXt/wdAr/QnEAlua5bSagVRC2t9X4lkcrFJSSfEA2J29Lh16pPzOK/HReo8R89wbEKfqrqZG/FNrjMB6YaAxBRJE0O9T6BDsMBCg6b8wb6DRPIKzuEkKkI9ywExVrVFOEANTsdS0oQq8exIlWHmnKwOf1R2Jl1FRgIHnJAfG29EoeY7Q+DlPZOBXqB+xamYj56h6FMb0ZLBOAirXm76bHbqJhzY5RbcW8HrxzvLBY1xfOlP4NMKWIxBNG1j2Je0WPU9gVDnq7/LoS0OuCtR'
+    options:
+      - 'command="deployScript.sh"'
+      - 'no-agent-forwarding'
+      - 'no-port-forwarding'
 ```
 
 ```
@@ -166,6 +176,10 @@ sshkeys::keys:
   second-test-key:
     type: 'ssh-rsa'
     key: 'AAAAB3NzaC1yc2EAAAADAQABAAABAQCqlo0PPGZ2XW1qBFuFgYmsGlT24I+v51tb7cRSAJeBouDPvfqBMBOX84ye4DsW3uRmFNXt/wdAr/QnEAlua5bSagVRC2t9X4lkcrFJSSfEA2J29Lh16pPzOK/HReo8R89wbEKfqrqZG/FNrjMB6YaAxBRJE0O9T6BDsMBCg6b8wb6DRPIKzuEkKkI9ywExVrVFOEANTsdS0oQq8exIlWHmnKwOf1R2Jl1FRgIHnJAfG29EoeY7Q+DlPZOBXqB+xamYj56h6FMb0ZLBOAirXm76bHbqJhzY5RbcW8HrxzvLBY1xfOlP4NMKWIxBNG1j2Je0WPU9gVDnq7/LoS0OuCtR'
+    options:
+      - 'command="deployScript.sh"'
+      - 'no-agent-forwarding'
+      - 'no-port-forwarding'
 ```
 
 ```

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -11,6 +11,7 @@
 define sshkeys::key (
     $key_name = undef,
     $key      = undef,
+    $options  = undef,
     $type     = undef,
     $user     = undef,
   ) {
@@ -27,17 +28,20 @@ define sshkeys::key (
     }
     $fin_key = $keys_hash[$key_name]['key']
     $fin_type = $keys_hash[$key_name]['type']
+    $fin_options = $keys_hash[$key_name]['options']
   } elsif ( $key and $type ) {
     $fin_key = $key
     $fin_type = $type
+    $fin_options = $options
   } else {
     fail ( 'either key and type both should be defined or both should be absent')
   }
 
   ssh_authorized_key { "${key_name}_at_${user}@${::fqdn}":
-    ensure => present,
-    user   => $user,
-    key    => $fin_key,
-    type   => $fin_type,
+    ensure  => present,
+    user    => $user,
+    key     => $fin_key,
+    options => $fin_options,
+    type    => $fin_type,
   }
 }


### PR DESCRIPTION
This adds support for the "options" attribute, which is supported by the ssh_authorized_key type.
I've updated README.md and added an example to demonstrate how to use the new attribute.

The result is a more powerful authorized_keys file:

```
command="deployScript.sh",no-agent-forwarding,no-port-forwarding ssh-rsa AAAAB3... user@host
```