### PR TITLE
Fix legacy API functions with Puppet >= 5.5.7

### DIFF
--- a/lib/puppet/parser/functions/sshkeys_convert_to_hash.rb
+++ b/lib/puppet/parser/functions/sshkeys_convert_to_hash.rb
@@ -11,35 +11,31 @@
 #
 # sshkeys_convert_to_hash (array, user, host)
 #
-module Puppet
-  module Parser
-    module Functions # rubocop:disable Style/Documentation
-      newfunction(
-        :sshkeys_convert_to_hash,
-        type: :rvalue,
-        doc: 'Converts the input array to the according sshkeys hash'
-      ) do |args|
-        raise(Puppet::ParseError, 'sshkeys_convert_to_hash(): wrong number of arguments ' \
-          "given (#{args.size} for 1)") if args.size != 3
+module Puppet::Parser::Functions # rubocop:disable Style/Documentation
+  newfunction(
+    :sshkeys_convert_to_hash,
+    type: :rvalue,
+    doc: 'Converts the input array to the according sshkeys hash'
+  ) do |args|
+    raise(Puppet::ParseError, 'sshkeys_convert_to_hash(): wrong number of arguments ' \
+      "given (#{args.size} for 1)") if args.size != 3
 
-        arr = args[0]
-        user = args[1]
-        host = args[2]
+    arr = args[0]
+    user = args[1]
+    host = args[2]
 
-        raise(Puppet::ParseError, 'sshkeys_convert_to_hash(): first argument should be an array') \
-          unless arr.is_a?(Array)
+    raise(Puppet::ParseError, 'sshkeys_convert_to_hash(): first argument should be an array') \
+      unless arr.is_a?(Array)
 
-        keys_hash = Hash[]
+    keys_hash = Hash[]
 
-        arr.each do |x|
-          keys_hash["#{x}_at_#{user}@#{host}"] = Hash[
-            'key_name' => x,
-            'user'     => user,
-            ]
-        end
-
-        return keys_hash
-      end
+    arr.each do |x|
+      keys_hash["#{x}_at_#{user}@#{host}"] = Hash[
+        'key_name' => x,
+        'user'     => user,
+        ]
     end
+
+    return keys_hash
   end
 end

--- a/lib/puppet/parser/functions/sshkeys_restruct_to_hash.rb
+++ b/lib/puppet/parser/functions/sshkeys_restruct_to_hash.rb
@@ -11,38 +11,34 @@
 #
 # sshkeys_restruct_to_hash (hash,user,host)
 #
-module Puppet
-  module Parser
-    module Functions # rubocop:disable Style/Documentation
-      newfunction(
-        :sshkeys_restruct_to_hash,
-        type: :rvalue,
-        doc: 'Converts the input hash to the according sshkeys hash with uniq keys to have uniq defines'
-      ) do |args|
-        raise(Puppet::ParseError, 'sshkeys_restruct_to_hash(): wrong number of arguments ' \
-          "given (#{args.size} for 1)") if args.size != 3
+module Puppet::Parser::Functions # rubocop:disable Style/Documentation
+  newfunction(
+    :sshkeys_restruct_to_hash,
+    type: :rvalue,
+    doc: 'Converts the input hash to the according sshkeys hash with uniq keys to have uniq defines'
+  ) do |args|
+    raise(Puppet::ParseError, 'sshkeys_restruct_to_hash(): wrong number of arguments ' \
+      "given (#{args.size} for 1)") if args.size != 3
 
-        input_hash = args[0]
-        user = args[1]
-        host = args[2]
+    input_hash = args[0]
+    user = args[1]
+    host = args[2]
 
-        raise(Puppet::ParseError, 'sshkeys_restruct_to_hash(): first argument should be a hash') unless input_hash.is_a?(Hash) # rubocop:disable Metrics/LineLength
+    raise(Puppet::ParseError, 'sshkeys_restruct_to_hash(): first argument should be a hash') unless input_hash.is_a?(Hash) # rubocop:disable Metrics/LineLength
 
-        keys_hash = Hash[]
+    keys_hash = Hash[]
 
-        input_hash.each do |x, val|
-          raise(Puppet::ParseError, 'sshkeys_restruct_to_hash(): wrong structure of input hash') if !val['key'] || !val['type'] # rubocop:disable Metrics/LineLength
-          keys_hash["#{x}_at_#{user}@#{host}"] = Hash[
-            'key_name' => x,
-            'user'     => user,
-            'key'      => val['key'],
-            'options'  => val['options'],
-            'type'     => val['type'],
-            ]
-        end
-
-        return keys_hash
-      end
+    input_hash.each do |x, val|
+      raise(Puppet::ParseError, 'sshkeys_restruct_to_hash(): wrong structure of input hash') if !val['key'] || !val['type'] # rubocop:disable Metrics/LineLength
+      keys_hash["#{x}_at_#{user}@#{host}"] = Hash[
+        'key_name' => x,
+        'user'     => user,
+        'key'      => val['key'],
+        'options'  => val['options'],
+        'type'     => val['type'],
+        ]
     end
+
+    return keys_hash
   end
 end


### PR DESCRIPTION
Since changes for [PUP-6964] added in version 5.5.7, Puppet requires 3.x
functions to include the string Puppet::Parser::Functions, otherwise it
will raise an exception.

This patch replaces nested module declarations with a single one to
pass this somewhat hacky check.

[PUP-6964]: https://tickets.puppetlabs.com/browse/PUP-6964

See [ruby_legacy_function_instantiator.rb#L16](https://github.com/puppetlabs/puppet/blob/96fce1c672ca416046cf6121808db82f9fae8b80/lib/puppet/pops/loader/ruby_legacy_function_instantiator.rb#L16) and https://github.com/puppetlabs/puppet/commit/f829da9de3c66c3ac980891fc38c1e0b6e8fb435

If in doubt, try viewing the changes with --ignore-space-change